### PR TITLE
Solved what I believe is a bug. Could be debatable. Let's discuss it.

### DIFF
--- a/src/lib/statuses.ts
+++ b/src/lib/statuses.ts
@@ -61,21 +61,14 @@ export const getGuessStatuses = (guess: string): CharStatus[] => {
   const splitSolution = solution.split('')
   const splitGuess = guess.split('')
 
-  const solutionCharsTaken = splitSolution.map((_) => false)
-
   const statuses: CharStatus[] = Array.from(Array(guess.length))
 
   // handle all correct cases first
   splitGuess.forEach((letter, i) => {
     if (letter === splitSolution[i]) {
       statuses[i] = 'correct'
-      solutionCharsTaken[i] = true
       return
     }
-  })
-
-  splitGuess.forEach((letter, i) => {
-    if (statuses[i]) return
 
     if (!splitSolution.includes(letter)) {
       // handles the absent case
@@ -84,18 +77,7 @@ export const getGuessStatuses = (guess: string): CharStatus[] => {
     }
 
     // now we are left with "present"s
-    const indexOfPresentChar = splitSolution.findIndex(
-      (x, index) => x === letter && !solutionCharsTaken[index]
-    )
-
-    if (indexOfPresentChar > -1) {
-      statuses[i] = 'present'
-      solutionCharsTaken[indexOfPresentChar] = true
-      return
-    } else {
-      statuses[i] = 'absent'
-      return
-    }
+    statuses[i] = 'present';
   })
 
   return statuses


### PR DESCRIPTION
Currently, if your guess has a letter repeated two times, and this letter exists in the solution, and your guess has this letter once in the correct place, and once in the wrong place, then the correct place will be Green/Blue, but the wrong place will be Gray, when I believe it should be Orange/Yellow.

Example:
If the correct solution is: REBUT
and your guess is: RESET
Then You will get: [blue,blue,gray,gray,gray], when I believe you should get [blue,blue,gray,yellow,gray].
The game info mentions that a Gray color means: "The letter U is not in the word in any spot.", and an Orange color means: "The letter L is in the word but in the wrong spot.". I believe that the Orange is what applies on the second E in RESET.

This is only debatable because it seems that the actual Wordle game has the same "problem".